### PR TITLE
Yarn 4.3 requires Node 18+ and GHA was complaining generally about No…

### DIFF
--- a/.github/workflows/staging_cicd.yml
+++ b/.github/workflows/staging_cicd.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: '20.x'
 
       - name: Setup Env Vars
         run: |
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: '20.x'
 
       - name: Setup Env Vars
         run: |
@@ -82,7 +82,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: '20.x'
 
       - name: Setup Env Vars
         run: |
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: '20.x'
 
       - name: Setup Env Vars
         run: |
@@ -141,8 +141,7 @@ jobs:
 
   build-nginx:
     runs-on: ubuntu-latest
-    needs:
-      [build-public, build-admin, build-public-redesign, build-django-static]
+    needs: [build-public, build-admin, build-public-redesign, build-django-static]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
…de 16 being EOL